### PR TITLE
Fix bug

### DIFF
--- a/src/L.TileLayer.WMS.GetFeatureInfo.js
+++ b/src/L.TileLayer.WMS.GetFeatureInfo.js
@@ -85,8 +85,8 @@ L.TileLayer.WMS.include({
           requestParamaters['bbox'] = version >= 1.3 && crs === L.CRS.EPSG4326 ?
             se.y + ',' + nw.x + ',' + nw.y + ',' + se.x :
             nw.x + ',' + se.y + ',' + se.x + ',' + nw.y;
-          requestParamaters[version >= 1.3 ? 'i' : 'x'] = point.x;
-          requestParamaters[version >= 1.3 ? 'j' : 'y'] = point.y;
+          requestParamaters[version >= 1.3 ? 'i' : 'x'] = Math.round(point.x);
+          requestParamaters[version >= 1.3 ? 'j' : 'y'] = Math.round(point.y);
         } catch (e) {
           fail(e);
 


### PR DESCRIPTION
I/x and J/y incorrectly specified
when x or y is decimal, geoserver throws an exception. we should round it and then send the request.